### PR TITLE
remove promisify and bind pool.query method

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-const promisify = require('util.promisify')
 const pg = require('pg')
 
 function fastifyPostgres (fastify, options, next) {
@@ -11,32 +10,8 @@ function fastifyPostgres (fastify, options, next) {
     connect: pool.connect.bind(pool),
     pool: pool,
     Client: pg.Client,
-    query: promisify(query)
+    query: pool.query.bind(pool)
   })
-
-  function query (text, value, callback) {
-    if (typeof value === 'function') {
-      callback = value
-      value = null
-    }
-
-    pool.connect(onConnect)
-
-    function onConnect (err, client, release) {
-      if (err) return callback(err)
-
-      if (value) {
-        client.query(text, value, onResult)
-      } else {
-        client.query(text, onResult)
-      }
-
-      function onResult (err, result) {
-        release()
-        callback(err, result)
-      }
-    }
-  }
 
   fastify.addHook('onClose', onClose)
 

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
   "homepage": "https://github.com/fastify/fastify-postgres#readme",
   "dependencies": {
     "fastify-plugin": "^0.1.1",
-    "pg": "^7.3.0",
-    "util.promisify": "^1.0.0"
+    "pg": "^7.3.0"
   },
   "devDependencies": {
     "fastify": "^0.29.2",


### PR DESCRIPTION
Since we are using pool, and we expose Client, I think query must be the function associated with the pool object to let pool handle client connection and client release in a more performant way.