### PR TITLE
Bring your own node-postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Under the hood the [node-postgres](https://github.com/brianc/node-postgres) is u
 
 ## Install
 ```
-npm i fastify-postgres --save
+npm i pg fastify-postgres --save
 ```
 ## Usage
 Add it to you project with `register` and you are done!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-postgres",
-  "version": "1.3.2",
+  "version": "2.0.0",
   "description": "Fastify PostgreSQL connection plugin",
   "main": "index.js",
   "scripts": {
@@ -27,13 +27,16 @@
   },
   "homepage": "https://github.com/fastify/fastify-postgres#readme",
   "dependencies": {
-    "fastify-plugin": "^1.4.0",
-    "pg": "^7.8.0"
+    "fastify-plugin": "^1.4.0"
   },
   "devDependencies": {
     "fastify": "^1.13.4",
+    "pg": "*",
     "pg-native": "^3.0.0",
     "standard": "^12.0.0",
     "tap": "^12.5.2"
+  },
+  "peerDependencies": {
+    "pg": ">=6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-postgres",
-  "version": "2.0.0",
+  "version": "1.3.2",
   "description": "Fastify PostgreSQL connection plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR will add `node-postgres` as a `peerDependency` forcing you to bring your own version.
As a side-effect of this change, the library's version will require a major version bump since we cannot guarantee backward-compatibility for everyone.

The earliest version of `pg` that I could find that we can support is technically [`>=5.0.0`](https://github.com/brianc/node-postgres/blob/master/CHANGELOG.md#v500) (calling `pg.native` will return `null` in case the native library was not installed), but the tests rely on `pg.Pool` which was introduced in [`6.0.0`](https://github.com/brianc/node-postgres/blob/master/CHANGELOG.md#new-features), hence the safest version we can support right now is `6.0.0`.

If we want to safely add support for `5.0.0` we'll have to re-write the tests to remove dependency on `pg.Pool`.

Fixes https://github.com/fastify/fastify-postgres/issues/42.