### PR TITLE
Add a GitHub Actions powered CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,41 @@
+name: GitHub CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [6, 8, 10, 12, 13]
+    
+    name: Node.js ${{ matrix.node }}
+    
+    services:
+      postgres:
+        image: postgres:11-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_DB: postgres
+        ports:
+        # will assign a random free host port
+        - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: CI environment setup
+      run: |
+        npm i node-gyp 
+        sudo apt-get install -yqq libpq-dev postgresql-client
+        psql -h localhost -p ${{ job.services.postgres.ports[5432] }} -d postgres -c 'CREATE TABLE users(id serial PRIMARY KEY, username VARCHAR (50) NOT NULL);' -U postgres
+
+    - name: Install
+      run: npm install
+
+    - name: Run tests      
+      run: npm run test


### PR DESCRIPTION
Hello ^^

As titled this PR adds a GitHub Actions powered CI (for now I did not remove Travis as the GitHub Actions service is still in beta):
- There's no longer any needs to compile `libpq` from the sources to run the `pg-native` test and overall it's more faster than Travis in general.
- Adds Node.js 13.x to the CI matrix

Feel free to ping me if changes need to be made ^^

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
