### PR TITLE
Allow named and unnamed connections at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ fastify.listen(3000, err => {
 As you can see there is no need to close the client, since is done internally. Promises and async await are supported as well.
 
 ### Name option
-If you need to have multiple databases set up, then you can name each one of them by passing `name: 'foo'`. It will then be accessible as `fastify.pg.foo` instead of `fastify.pg`.
-You can't use both named and an unnamed postgres conenction at once.
+If you need to have multiple databases set up, then you can name each one of them by passing `name: 'foo'`. It will then be accessible as `fastify.pg.foo`.
+You can use both unnamed and named postgres connections at once. There can be only one unnamed connection, and it will be accessible as `fastify.pg`.
 
 ```js
 const fastify = require('fastify')()

--- a/index.js
+++ b/index.js
@@ -83,20 +83,22 @@ function fastifyPostgres (fastify, options, next) {
   fastify.addHook('onClose', (fastify, done) => pool.end(done))
 
   if (name) {
-    if (!fastify.pg) {
+    if (db[name]) {
+      return next(new Error(`fastify-postgres '${name}' is a reserved keyword`))
+    } else if (!fastify.pg) {
       fastify.decorate('pg', {})
-    } else if (fastify.pg.pool instanceof pg.Pool) {
-      return next(new Error('fastify-postgres already has an unnamed instance registered'))
     } else if (fastify.pg[name]) {
       return next(new Error(`fastify-postgres '${name}' instance name has already been registered`))
     }
 
     fastify.pg[name] = db
   } else {
-    if (fastify.pg) {
+    if (!fastify.pg) {
+      fastify.decorate('pg', db)
+    } else if (fastify.pg.pool) {
       return next(new Error('fastify-postgres has already been registered'))
     } else {
-      fastify.decorate('pg', db)
+      Object.assign(fastify.pg, db)
     }
   }
 

--- a/test/initialization.test.js
+++ b/test/initialization.test.js
@@ -110,24 +110,23 @@ test('Should throw when trying to register multiple instances without giving a n
   })
 })
 
-test('Should throw when trying to register a named instance after an unnamed', (t) => {
-  t.plan(2)
+test('Should not throw when registering a named instance and an unnamed instance)', (t) => {
+  t.plan(1)
 
   const fastify = Fastify()
   t.teardown(() => fastify.close())
 
   fastify.register(fastifyPostgres, {
-    connectionString
+    connectionString,
+    name: 'one'
   })
 
   fastify.register(fastifyPostgres, {
-    connectionString,
-    name: 'two'
+    connectionString
   })
 
   fastify.ready((err) => {
-    t.ok(err)
-    t.is((err || {}).message, 'fastify-postgres already has an unnamed instance registered')
+    t.error(err)
   })
 })
 
@@ -151,6 +150,24 @@ test('Should throw when trying to register duplicate connection names', (t) => {
   fastify.ready((err) => {
     t.ok(err)
     t.is((err || {}).message, `fastify-postgres '${name}' instance name has already been registered`)
+  })
+})
+
+test('Should throw when trying to register a named connection with a reserved keyword', (t) => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  t.teardown(() => fastify.close())
+  const name = 'Client'
+
+  fastify.register(fastifyPostgres, {
+    connectionString,
+    name
+  })
+
+  fastify.ready((err) => {
+    t.ok(err)
+    t.is((err || {}).message, `fastify-postgres '${name}' is a reserved keyword`)
   })
 })
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Resolves https://github.com/fastify/fastify-postgres/issues/72

This allows usage of named connections along with unnamed connections at the same time. A restriction is also placed to ensure that the name is not any of the reserved properties.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
