### PR TITLE
Docs: use try/finally to always release the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ fastify.get('/user/:id', async (req, reply) => {
     const { rows } = await client.query(
       'SELECT id, username, hash, salt FROM users WHERE id=$1', [req.params.id],
     )
+    // Note: avoid doing expensive computation here, this will block releasing the client
     return rows
   } finally {
+    // Release the client immediately after query resolves, or upon error
     client.release()
   }
 })

--- a/README.md
+++ b/README.md
@@ -64,11 +64,14 @@ fastify.register(require('@fastify/postgres'), {
 
 fastify.get('/user/:id', async (req, reply) => {
   const client = await fastify.pg.connect()
-  const { rows } = await client.query(
-    'SELECT id, username, hash, salt FROM users WHERE id=$1', [req.params.id],
-  )
-  client.release()
-  return rows
+  try {
+    const { rows } = await client.query(
+      'SELECT id, username, hash, salt FROM users WHERE id=$1', [req.params.id],
+    )
+    return rows
+  } finally {
+    client.release()
+  }
 })
 
 fastify.listen(3000, err => {
@@ -233,7 +236,7 @@ fastify.listen(3000, err => {
 ```
 
 ### Transact route option
-It is possible to automatically wrap a route handler in a transaction by using the `transact` option when registering a route with Fastify. Note that the option must be scoped within a `pg` options object to take effect. 
+It is possible to automatically wrap a route handler in a transaction by using the `transact` option when registering a route with Fastify. Note that the option must be scoped within a `pg` options object to take effect.
 
 `query` commands can then be accessed at `request.pg` or `request.pg[name]` and `transact` can be set for either the root pg client with value `true` or for a pg client at a particular namespace with value `name`. Note that the namespace needs to be set when registering the plugin in order to be available on the request object.
 


### PR DESCRIPTION
Use try/finally to always release the client on error before handling

Refs: https://node-postgres.com/features/pooling#examples

```js
// async/await - check out a client
;(async () => {
  const client = await pool.connect()
  try {
    const res = await client.query('SELECT * FROM users WHERE id = $1', [1])
    console.log(res.rows[0])
  } finally {
    // Make sure to release the client before any error handling,
    // just in case the error handling itself throws an error.
    client.release()
  }
})().catch(err => console.log(err.stack))
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
