### PR TITLE
Fix Tests random failure

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ function fastifyPostgres (fastify, options, next) {
         }
       }
 
-      client.query('BEGIN')
+      await client.query('BEGIN')
     }
 
     const onError = (req, reply, error, done) => {

--- a/test/req-initialization.test.js
+++ b/test/req-initialization.test.js
@@ -16,7 +16,7 @@ test('When we use the fastify-postgres transaction route option', t => {
       connectionString
     })
 
-    await fastify.pg.query('TRUNCATE users')
+    await fastify.pg.query('DELETE FROM "users" WHERE TRUE')
 
     fastify.get('/count-users', async (req, reply) => {
       const result = await fastify.pg.query('SELECT COUNT(*) AS "userCount" FROM users WHERE username=\'pass-opt-in\'')
@@ -49,7 +49,7 @@ test('When we use the fastify-postgres transaction route option', t => {
       name: 'test'
     })
 
-    await fastify.pg.test.query('TRUNCATE users')
+    await fastify.pg.test.query('DELETE FROM "users" WHERE TRUE')
 
     fastify.get('/count-users', async (req, reply) => {
       const result = await fastify.pg.test.query('SELECT COUNT(*) AS "userCount" FROM users WHERE username=\'pass-opt-in\'')
@@ -82,7 +82,7 @@ test('When we use the fastify-postgres transaction route option', t => {
       connectionString
     })
 
-    await fastify.pg.query('TRUNCATE users')
+    await fastify.pg.query('DELETE FROM "users" WHERE TRUE')
 
     fastify.get('/count-users', async (req, reply) => {
       const result = await fastify.pg.query('SELECT COUNT(*) AS "userCount" FROM users WHERE username=\'fail-opt-in\'')
@@ -117,7 +117,7 @@ test('When we use the fastify-postgres transaction route option', t => {
       name: 'test'
     })
 
-    await fastify.pg.test.query('TRUNCATE users')
+    await fastify.pg.test.query('DELETE FROM "users" WHERE TRUE')
 
     fastify.get('/count-users', async (req, reply) => {
       const result = await fastify.pg.test.query('SELECT COUNT(*) AS "userCount" FROM users WHERE username=\'fail-opt-in\'')


### PR DESCRIPTION
I noticed that randomly test fails on my machine (docker hosted on macos 13). This is (probably) caused by 2 issues:

1) missed await on query("BEGIN") 
2) the use of `TRUNCATE` on each test.

as explained here (https://www.postgresql.org/docs/current/mvcc-caveats.html) `TRUNCATE` is not MVCC-safe (Multi-Version Concurrency Control).

This PR adds the missing `await` and converts all the `TRUNCATE users` in `DELETE FROM "users" WHERE TRUE`.

Because the tests inside the req-initialization file do not verify user IDs, the proposed query has the same effect as a `TRUNCATE` in this context

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
