### PR TITLE
Update for Fastify v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   test:
-    uses: fastify/workflows/.github/workflows/plugins-ci-postgres.yml@v3
+    uses: fastify/workflows/.github/workflows/plugins-ci-postgres.yml@4.1.0
     with:
       license-check: true
       lint: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   test:
-    uses: fastify/workflows/.github/workflows/plugins-ci-postgres.yml@4.1.0
+    uses: fastify/workflows/.github/workflows/plugins-ci-postgres.yml@v4.1.0
     with:
       license-check: true
       lint: true

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "load-data": "docker exec -it fastify-postgres psql -c 'CREATE TABLE users(id serial PRIMARY KEY, username VARCHAR (50) NOT NULL);' -U postgres -d postgres",
     "postgres": "docker run -p 5432:5432 --name fastify-postgres -e POSTGRES_PASSWORD=postgres -d postgres:11-alpine",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "tap -J test/*.test.js",
-    "test:report": "standard && tap -J --coverage-report=html test/*.test.js",
+    "test:unit": "tap test/*.test.js",
+    "test:report": "standard && tap --coverage-report=html test/*.test.js",
     "test:typescript": "tsd",
-    "test:verbose": "standard && tap -J test/*.test.js -Rspec"
+    "test:verbose": "standard && tap test/*.test.js -Rspec"
   },
   "repository": {
     "type": "git",
@@ -36,18 +36,18 @@
   },
   "homepage": "https://github.com/fastify/fastify-postgres#readme",
   "dependencies": {
-    "fastify-plugin": "^4.0.0"
+    "fastify-plugin": "^4.5.1"
   },
   "devDependencies": {
-    "@tsconfig/node10": "^1.0.8",
-    "@types/pg": "^8.6.1",
-    "fastify": "^4.0.0-rc.2",
-    "pg": "^8.7.1",
-    "pg-native": "^3.0.0",
-    "standard": "^17.0.0",
-    "tap": "^16.0.0",
-    "tsd": "^0.30.0",
-    "typescript": "^5.0.2"
+    "@tsconfig/node10": "^1.0.9",
+    "@types/pg": "^8.11.4",
+    "fastify": "^4.26.2",
+    "pg": "^8.11.3",
+    "pg-native": "^3.0.1",
+    "standard": "^17.1.0",
+    "tap": "^18.7.1",
+    "tsd": "^0.30.7",
+    "typescript": "^5.4.3"
   },
   "peerDependencies": {
     "pg": ">=6.0.0"


### PR DESCRIPTION
Ref: https://github.com/fastify/fastify/issues/5116

⚠️ I've removed the `-J` arg from `tap`. This was used to run jobs in parallel which is already enabled by default in v18 [docs](https://node-tap.org/cli/#-j<n>---jobs%3D<n>)

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

CC @simoneb 