### PR TITLE
fix(types): type pg Client as the constructor (typeof Pg.Client)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,7 @@ type FastifyPostgres = FastifyPluginCallback<fastifyPostgres.PostgresPluginOptio
 declare namespace fastifyPostgres {
   export type PostgresDb = {
     pool: Pg.Pool;
-    Client: Pg.Client;
+    Client: typeof Pg.Client;
     query: Pg.Pool['query'];
     connect: Pg.Pool['connect'];
     transact: typeof transact;

--- a/test-types/query.tst.ts
+++ b/test-types/query.tst.ts
@@ -13,7 +13,7 @@ app.get('/calc', async () => {
   expect(app.pg).type.toBeAssignableTo<PostgresDb>()
 
   expect(app.pg.pool).type.toBe<Pool>()
-  expect(app.pg.Client).type.toBe<Client>()
+  expect(app.pg.Client).type.toBe<typeof Client>()
 
   const client = await app.pg.connect()
   expect(client).type.toBe<PoolClient>()


### PR DESCRIPTION
## What

Change the `Client` member of the public `PostgresDb` type from `Pg.Client` to `typeof Pg.Client`.

## Why

At runtime the plugin assigns the pg Client **class** (the constructor) to `app.pg.Client`:

```js
// index.js
const db = {
  connect: pool.connect.bind(pool),
  pool,
  Client: pg.Client, // <- the constructor/class, not an instance
  query: pool.query.bind(pool),
  transact: transact.bind(pool)
}
```

But the type declaration described it as an instance:

```ts
// index.d.ts (before)
export type PostgresDb = {
  pool: Pg.Pool;
  Client: Pg.Client; // instance type
  ...
}
```

Since `@types/pg` declares `export class Client`, `Pg.Client` is the *instance* type and `typeof Pg.Client` is the *constructor* type. As a result, instantiating a one-off client via the decorator — `new app.pg.Client({ connectionString })` — failed to type-check:

```
error TS2351: This expression is not constructable.
  Type 'Client' has no construct signatures.
```

even though it works at runtime.

## Change

```ts
// index.d.ts (after)
Client: typeof Pg.Client;
```

and the corresponding type test now asserts the constructor type:

```ts
expect(app.pg.Client).type.toBe<typeof Client>()
```

## Testing

- `npm run test:typescript` (tstyche): all 4 type-test files pass, 13/13 assertions pass.
- `npm run lint`: clean.
- Verified `new app.pg.Client({ connectionString })` now type-checks (no TS2351), and reproduced the failure before the change.

This is a type-only change with no runtime impact, so unit-test coverage (`c8 --100`) is unaffected.
