### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,8 +325,10 @@ $ npm test
 ## Acknowledgments
 
 This project is kindly sponsored by:
-- [nearForm](https://www.nearform.com)
-- [LetzDoIt](https://www.letzdoitapp.com/)
+- [nearForm](https://nearform.com)
+
+Past sponsors:
+- LetzDoIt
 
 ## License
 


### PR DESCRIPTION
Fixes 404s, 3xx redirections, and missing fragments in the documentation. Part of general link cleanup being tracked in https://github.com/fastify/accept-negotiator/pull/71